### PR TITLE
SP11/SP6/02-03 Business user can not register because of invalid Config Code

### DIFF
--- a/new_pom/modalWindows/confirmCodeModal.js
+++ b/new_pom/modalWindows/confirmCodeModal.js
@@ -1,6 +1,6 @@
 import { URL_END_POINTS } from '../../testData';
 import { step } from 'allure-js-commons';
-import ToastComponent from "../components/toastComponent";
+import ToastComponent from '../components/toastComponent';
 
 export default class ConfirmCodeModal {
     constructor(page) {

--- a/new_pom/modalWindows/confirmCodeModal.js
+++ b/new_pom/modalWindows/confirmCodeModal.js
@@ -1,13 +1,17 @@
 import { URL_END_POINTS } from '../../testData';
 import { step } from 'allure-js-commons';
+import ToastComponent from "../components/toastComponent";
 
 export default class ConfirmCodeModal {
     constructor(page) {
         this.page = page;
 
+        this.toast = new ToastComponent(this.page);
+
         this.confirmCodeModalTitle = this.page.locator('.confirmCodeModal__title');
         this.confirmCodeInputField = this.page.getByPlaceholder('0A2b3C4d5E');
         this.sendButton = this.page.getByRole('button', { name: 'Send', exact: true });
+        this.resendButton = this.page.getByRole('button', { name: 'Resend', exact: true });
     }
 
     async fillConfirmCodeInputField(code) {
@@ -20,6 +24,18 @@ export default class ConfirmCodeModal {
         await step('Click on "Send" button.', async () => {
             await this.sendButton.click();
             await this.page.waitForURL(`${process.env.URL}${URL_END_POINTS.signEndPoint}`);
+        });
+    }
+
+    async clickSendButtonAndStay() {
+        await step('Click on "Send" button.', async () => {
+            await this.sendButton.click();
+        });
+    }
+
+    async clickResendButton() {
+        await step('Click on "Send" button.', async () => {
+            await this.resendButton.click();
         });
     }
 }

--- a/testData.js
+++ b/testData.js
@@ -338,4 +338,4 @@ export const NEGATIVE_CONFIRM_CODE = [
         desc: 'trailing space in Confirm Code',
         value: ' ',
     },
-]
+];

--- a/testData.js
+++ b/testData.js
@@ -58,6 +58,7 @@ export const TOAST_MESSAGE = {
     permissionsChanged: 'Permissions successfully changed!',
     templateNoSigner: 'Document must have at least one signer',
     incorrectEmailOrPassword: 'Email or password incorrect. Please try again.',
+    invalidConfirmCode: 'Confirm code is not valid.',
 };
 
 export const API_KEY_NAME = 'Test Api Key';
@@ -319,3 +320,22 @@ export const NEGATIVE_BUSINESS_USER_REGISTRATION = [
 export const ERROR_WARNING_BACKGROUND_COLOR = 'rgb(255, 243, 243)';
 export const TITLE_OF_PREPARE_FOR_SIGNATURE_MODAL = 'Prepare for Signing';
 export const INCORRECT_USER_EMAIL = 'test@gmail.com';
+
+export const NEGATIVE_CONFIRM_CODE = [
+    {
+        desc: 'Empty Confirm Code field',
+        value: '',
+    },
+    {
+        desc: 'Invalid Confirm Code',
+        value: 'cxP87lUSPX10',
+    },
+    {
+        desc: 'leading space in Confirm Code',
+        value: ' ',
+    },
+    {
+        desc: 'trailing space in Confirm Code',
+        value: ' ',
+    },
+]

--- a/tests_advance/registration.spec.js
+++ b/tests_advance/registration.spec.js
@@ -14,7 +14,7 @@ import {
     PLEASE_ENTER_CONFIRMATION_CODE,
     TOAST_MESSAGE,
 } from '../testData';
-import {generateNewUserData, retrieveUserEmailConfirmCode} from '../helpers/utils';
+import { generateNewUserData, retrieveUserEmailConfirmCode } from '../helpers/utils';
 import { description, tags, severity, Severity, epic, step, tag, link } from 'allure-js-commons';
 import { signUpTrialUserWithoutPayment } from '../helpers/preconditions';
 
@@ -212,7 +212,9 @@ test.describe('Negative tests for Trial user registration', () => {
             signUpBusinessPage,
             confirmCodeModal,
         }) => {
-            await description(`To verify Business user can not register because "Send" button is disabled in case of ${desc}.`);
+            await description(
+                `To verify Business user can not register because "Send" button is disabled in case of ${desc}.`
+            );
             await tag('Business user');
             await severity(Severity.BLOCKER);
             await epic('Negative Registration');
@@ -239,12 +241,12 @@ test.describe('Negative tests for Trial user registration', () => {
             });
             let confirmCode;
 
-            if (desc === 'Empty Confirm Code field' ||  desc === 'Invalid Confirm Code') {
-                confirmCode = value
-            } else  if (desc === 'leading space in Confirm Code') {
-                confirmCode = " " + await retrieveUserEmailConfirmCode(request, newUserData.email);
-            } else  if (desc === 'trailing space in Confirm Code') {
-                confirmCode = await retrieveUserEmailConfirmCode(request, newUserData.email) + " ";
+            if (desc === 'Empty Confirm Code field' || desc === 'Invalid Confirm Code') {
+                confirmCode = value;
+            } else if (desc === 'leading space in Confirm Code') {
+                confirmCode = ' ' + (await retrieveUserEmailConfirmCode(request, newUserData.email));
+            } else if (desc === 'trailing space in Confirm Code') {
+                confirmCode = (await retrieveUserEmailConfirmCode(request, newUserData.email)) + ' ';
             }
             await confirmCodeModal.fillConfirmCodeInputField(confirmCode);
 
@@ -310,4 +312,3 @@ test.describe('Negative tests for Trial user registration', () => {
         });
     });
 });
-


### PR DESCRIPTION
TASK: https://signjstest.atlassian.net/jira/software/projects/SP/boards/1?selectedIssue=SP-6 

1. Test SP11/SP6/02 - Failed registration because of disabled 'Send' button in case of scenarios:
- Empty Confirm Code field,
- Invalid Confirm Code,
- leading space in Confirm Code,
- trailing space in Confirm Code.
2. Test SP11/SP6/02 - Failed registration because of expired Confirm Code.
